### PR TITLE
Add functions for service name resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## v1.1.0 - Oct 18, 2022
+
+### Added
+
+* Add functions for service name resolution
+
+
 ## v1.0.0 - Oct 04, 2022
 
 ### Initial Release

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ like for example portmappers.
 
 ![](https://github.com/usdAG/sunrpc/workflows/main%20Python%20CI/badge.svg?branch=main)
 ![](https://github.com/usdAG/sunrpc/workflows/develop%20Python%20CI/badge.svg?branch=develop)
-[![](https://img.shields.io/badge/version-1.0.0-blue)](https://github.com/usdAG/sunrpc/releases)
+[![](https://img.shields.io/badge/version-1.1.0-blue)](https://github.com/usdAG/sunrpc/releases)
 [![](https://img.shields.io/badge/build%20system-pip-blue)](https://pypi.org/project/sunrpc)
 ![](https://img.shields.io/badge/python-9%2b-blue)
 [![](https://img.shields.io/badge/license-GPL%20v3.0-blue)](https://github.com/usdAG/sunrpc/blob/main/LICENSE)

--- a/examples/portmapper-client.py
+++ b/examples/portmapper-client.py
@@ -73,14 +73,21 @@ def main():
         print('[+]')
 
         mappings = client.dump()
-        print('[+]     Prog    Vers    Prot    Port')
+        print('[+]        Prog    Vers    Prot    Port    Service')
 
         for item in mappings:
             print('[+]', end='')
-            print(str(item[0]).rjust(9), end='')
+            print(str(item[0]).rjust(12), end='')
             print(str(item[1]).rjust(8), end='')
             print(str(item[2]).rjust(8), end='')
-            print(str(item[3]).rjust(8))
+            print(str(item[3]).rjust(8), end='')
+
+            service_name = sunrpc.services.prog_to_name(item[0])
+            if service_name is not None:
+                print(' ' * 4 + service_name)
+
+            else:
+                print('')
 
     else:
         print('[-] Unknown action :(')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'sunrpc'
-version = '1.0.0'
+version = '1.1.0'
 authors = [ { name='Tobias Neitzel (@qtc_de)' }, ]
 description = 'sunrpc implements remote procedure calls according to RFC1057'
 readme = 'README.md'

--- a/sunrpc/__init__.py
+++ b/sunrpc/__init__.py
@@ -6,5 +6,7 @@ import sunrpc.proxy
 import sunrpc.portmapper
 import sunrpc.types
 import sunrpc.utils
+import sunrpc.services
 
 name = 'sunrpc'
+sunrpc.services.update_service_names()

--- a/sunrpc/services.py
+++ b/sunrpc/services.py
@@ -1,0 +1,151 @@
+import re
+from pathlib import Path
+
+
+known_services = {100000: ['portmapper', 'portmap', 'sunrpc', 'rpcbind'],
+                  100001: ['rstatd', 'rstat', 'rup', 'perfmeter', 'rstat_svc'],
+                  100002: ['rusersd', 'rusers'],
+                  100003: ['nfs', 'nfsprog'],
+                  100004: ['ypserv', 'ypprog'],
+                  100005: ['mountd', 'mount', 'showmount'],
+                  100007: ['ypbind'],
+                  100008: ['walld', 'rwall', 'shutdown'],
+                  100009: ['yppasswdd', 'yppasswd'],
+                  100010: ['etherstatd', 'etherstat'],
+                  100011: ['rquotad', 'rquotaprog', 'quota', 'rquota'],
+                  100012: ['sprayd', 'spray'],
+                  100013: ['3270_mapper'],
+                  100014: ['rje_mapper'],
+                  100015: ['selection_svc', 'selnsvc'],
+                  100016: ['database_svc'],
+                  100017: ['rexd', 'rex'],
+                  100018: ['alis'],
+                  100019: ['sched'],
+                  100020: ['llockmgr'],
+                  100021: ['nlockmgr'],
+                  100022: ['x25.inr'],
+                  100023: ['statmon'],
+                  100024: ['status'],
+                  100026: ['bootparam'],
+                  100028: ['ypupdated', 'ypupdate'],
+                  100029: ['keyserv', 'keyserver'],
+                  100033: ['sunlink_mapper'],
+                  100037: ['tfsd'],
+                  100038: ['nsed'],
+                  100039: ['nsemntd'],
+                  100043: ['showfhd', 'showfh'],
+                  100055: ['ioadmd', 'rpc.ioadmd'],
+                  100062: ['NETlicense'],
+                  100065: ['sunisamd'],
+                  100066: ['debug_svc', 'dbsrv'],
+                  100069: ['ypxfrd', 'rpc.ypxfrd'],
+                  100071: ['bugtraqd'],
+                  100078: ['kerbd'],
+                  100101: ['event', 'na.event'],
+                  100102: ['logger', 'na.logger'],
+                  100104: ['sync', 'na.sync'],
+                  100107: ['hostperf', 'na.hostperf'],
+                  100109: ['activity', 'na.activity'],
+                  100112: ['hostmem', 'na.hostmem'],
+                  100113: ['sample', 'na.sample'],
+                  100114: ['x25', 'na.x25'],
+                  100115: ['ping', 'na.ping'],
+                  100116: ['rpcnfs', 'na.rpcnfs'],
+                  100117: ['hostif', 'na.hostif'],
+                  100118: ['etherif', 'na.etherif'],
+                  100120: ['iproutes', 'na.iproutes'],
+                  100121: ['layers', 'na.layers'],
+                  100122: ['snmp', 'na.snmp', 'snmp-cmc', 'snmp-synoptics', 'snmp-unisys', 'snmp-utk'],
+                  100123: ['traffic', 'na.traffic'],
+                  100227: ['nfs_acl'],
+                  100232: ['sadmind'],
+                  100300: ['nisd', 'rpc.nisd'],
+                  100303: ['nispasswd', 'rpc.nispasswdd'],
+                  100233: ['ufsd', 'ufsd'],
+                  100418: ['fedfs_admin'],
+                  150001: ['pcnfsd', 'pcnfs'],
+                  300019: ['amd', 'amq'],
+                  391002: ['sgi_fam', 'fam'],
+                  545580417: ['bwnfsd'],
+                  600100069: ['fypxfrd', 'freebsd-ypxfrd']}
+
+
+def update_service_names():
+    '''
+    Attempt to parse the users local /etc/rpc file if present
+    and add the services to the known_services dict (if any).
+    This function is called automatically when the module is
+    loaded.
+
+    Parameters:
+        None
+
+    Returns:
+        None
+    '''
+    if not Path('/etc/rpc').is_file():
+        return
+
+    rpc_regex = re.compile(r'([^\s]+)\s+(\d+)(?:\s+(.+))?')
+
+    try:
+
+        with open('/etc/rpc') as f:
+            lines = f.readlines()
+
+        for line in lines:
+
+            line = line.split('#', 1)[0].strip()
+            match = rpc_regex.match(line)
+
+            if not match:
+                continue
+
+            service_names = [match.group(1)]
+
+            if match.group(3) is not None:
+                service_names += match.group(3).strip().split()
+
+            known_services[int(match.group(2))] = service_names
+
+    except Exception:
+        return
+
+
+def prog_to_name(prog_id: int, with_alias: bool = True) -> str:
+    '''
+    Attempts to resolve a prog_id to a human readable service name.
+    This is done by performing a lookup on the known_services dict.
+
+    Parameters:
+        prog_id     program id to lookup
+        with_alias  return the main program name and all its aliases
+
+    Returns:
+        Looked up program name (+aliases) or None
+    '''
+    name_list = known_services.get(prog_id)
+
+    if name_list is None:
+        return None
+
+    if len(name_list) == 1 or not with_alias:
+        return name_list[0]
+
+    return f'{name_list[0]} ({" ".join(name_list[1:])})'
+
+
+def name_to_prog(name: str) -> int:
+    '''
+    Attempts to resolve a prog_id by looking up its name.
+    The name can be the main service name or an alias.
+
+    Parameters:
+        name        program name to lookup
+
+    Returns:
+        Looked up program id
+    '''
+    for prog_id, service_names in known_services.items():
+        if name in service_names:
+            return prog_id


### PR DESCRIPTION
Add two functions that allow to resolve service names from prog_ids and vice versa. The module now contains a built in service list and attempts to parse the local /etc/rpc if present.